### PR TITLE
Update typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,26 +1,26 @@
 {
-    "scripts": {
-        "start": "nest start --watch"
-    },
-    "dependencies": {
-        "@nestjs/common": "^7.6.13",
-        "@nestjs/core": "^7.6.13",
-        "@nestjs/platform-express": "^7.6.13",
-        "@nestjs/platform-socket.io": "^7.6.13",
-        "@nestjs/websockets": "^7.6.13",
-        "@prisma/client": "^2.19.0",
-        "googleapis": "^68.0.0",
-        "nodemailer": "^6.5.0",
-        "prisma": "^2.19.0",
-        "reflect-metadata": "^0.1.13",
-        "rxjs": "^6.6.6",
-        "socket.io": "^3.1.2"
-    },
-    "devDependencies": {
-        "@nestjs/cli": "^7.5.6",
-        "@prisma/cli": "^2.19.0",
-        "@types/socket.io": "^2.1.13",
-        "dotenv": "^8.2.0",
-        "vercel": "^21.3.3"
-    }
+  "scripts": {
+    "start": "rm -rf build && nest start --watch"
+  },
+  "dependencies": {
+    "@nestjs/common": "^7.6.13",
+    "@nestjs/core": "^7.6.13",
+    "@nestjs/platform-express": "^7.6.13",
+    "@nestjs/platform-socket.io": "^7.6.13",
+    "@nestjs/websockets": "^7.6.13",
+    "@prisma/client": "^2.19.0",
+    "googleapis": "^68.0.0",
+    "nodemailer": "^6.5.0",
+    "prisma": "^2.19.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^6.6.6",
+    "socket.io": "^3.1.2"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^7.5.6",
+    "@prisma/cli": "^2.19.0",
+    "@types/socket.io": "^2.1.13",
+    "dotenv": "^8.2.0",
+    "vercel": "^21.3.3"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3218,6 +3218,11 @@ typescript@4.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
+typescript@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+
 unique-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"


### PR DESCRIPTION
**Bug Fixed**
- typescript version update.
  - 시작시 빌드된 내용에서 prsiam/client의 typescript버전 문제가 발생.
  - 최신버전의 typescript를 4.2.4으로 재설치 → 정상실행.
